### PR TITLE
[submit_gmx_mdrun.py]: Add Missing Option Check

### DIFF
--- a/simulation/gmx/submit_gmx_mdrun.py
+++ b/simulation/gmx/submit_gmx_mdrun.py
@@ -721,6 +721,13 @@ if __name__ == "__main__":  # noqa: C901
             sbatch += " --requeue"
         else:
             sbatch += " --no-requeue"
+        if args.NO_GUESS_THREADS or (
+            args.GMX_MPI_EXE is not None or args.GMX_MPI_EXE != 0
+        ):
+            raise ValueError(
+                "--ntasks-per-node must be provided via --sbatch if"
+                " --no-guess-threads and/or --gmx-exe-mpi is given"
+            )
     else:
         if (
             "--job-name" not in args.SB_OPTIONS


### PR DESCRIPTION
Before this fix, whether --ntasks-per-node must be provided via --sbatch
was only checked if --sbatch was actually given.  But this check must
also be done when --sbatch is not given.  This has now been fixed.