### PR TITLE
[gmx_get_num_steps_from_log.sh]: read_lines

### DIFF
--- a/bash/gmx_get_num_steps_from_log.sh
+++ b/bash/gmx_get_num_steps_from_log.sh
@@ -64,7 +64,7 @@ if [[ ! -f ${infile} ]]; then
     exit 1
 fi
 
-read_lines=150
+read_lines=200
 counter=1
 found_Statistics=false
 for string in $(tail -n "${read_lines}" "${infile}" || exit); do


### PR DESCRIPTION
Increase the number of lines to read from the bottom of the Gromacs log
file to 200.  150 is not always sufficient to find the word
"Statistics".