### PR TITLE
[submit_gmx_mdrun.py]: Change Default Backup Behavior

### DIFF
--- a/simulation/gmx/submit_gmx_mdrun.py
+++ b/simulation/gmx/submit_gmx_mdrun.py
@@ -55,13 +55,10 @@ Resubmission
     useful if your simulation takes longer than the maximum allowed
     simulation time on your computing cluster.  This option is ignored
     if \--continue is set to ``0`` or ``1``.  Default: ``10``.
---no-backup
-    By default, old simulation files will be backed up into a
-    subdirectory before continuing a previous simulation using |rsync|.
-    This might take up to a few hours depending on the size of the
-    files.  With \--no-backup you can skip this backup, but be aware
-    that your trajectory (and other simulation files) might get
-    corrupted if the continuation of the simulation fails badly.
+--backup
+    Backup old simulation files into a subdirectory using |rsync| before
+    continuing a previous simulation.  This might take up to a few hours
+    depending on the size of the files.
 
 Gromacs-Specifig Options
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -316,11 +313,14 @@ if __name__ == "__main__":  # noqa: C901
         ),
     )
     parser_resub.add_argument(
-        "--no-backup",
+        "--backup",
         required=False,
         default=False,
         action="store_true",
-        help="Skip backup before continuing a previous simulation.",
+        help=(
+            "Backup old simulation files before continuing a previous"
+            " simulation."
+        ),
     )
     parser_gmx = parser.add_argument_group(title="Gromacs-Specifig Options")
     parser_gmx.add_argument(
@@ -511,7 +511,7 @@ if __name__ == "__main__":  # noqa: C901
         args["structure"],
         args["continue"],
         nsteps,
-        not args["no_backup"],
+        args["backup"],
         gmx_lmod,
         args["gmx_exe"],
         args["gmx_mpi_exe"],


### PR DESCRIPTION
# [submit_gmx_mdrun.py]: Change Default Backup Behavior

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [ ] Non-breaking (backward-compatible) change.
* [x] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

From now on by default, don't backup old simulations files before continuing a previous simulation.

Change the `--no-backup` flag to a `--backup` flag.  This should be less confusing.  If users want to have backups by default, they can create an appropriate `.hpcssrc.ini` file.
