### PR TITLE
Change Default of `--every` Option of `submit_gmx_analyses_lintf2_ether.py`

### DIFF
--- a/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
@@ -57,7 +57,8 @@ Options for Trajectory Reading
     :file:`${settings}_out_${system}.log`.  Reading from |log_file|\s
     compressed with gzip, bzip2, XZ or LZMA is supported.
 --every
-    Only use frame if t MOD dt == first time (in ps).  Default: ``1``.
+    Only use frame if t MOD every == first time (in ps).  Default:
+    ``0``.
 
 Options for MSD Calculation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -454,9 +455,9 @@ if __name__ == "__main__":  # noqa: C901
         "--every",
         type=float,
         required=False,
-        default=1,
+        default=0,
         help=(
-            "Only use frame if t MOD dt == first time (in ps).  Default:"
+            "Only use frame if t MOD every == first time (in ps).  Default:"
             " %(default)s."
         ),
     )


### PR DESCRIPTION
# Change Default of `--every` Option of `submit_gmx_analyses_lintf2_ether.py`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [ ] Non-breaking (backward-compatible) change.
* [x] Breaking (non-backward-compatible) change.

## Proposed Changes

Change default of the --every option from 1 to 0.

The value of the --every option is parsed to the -dt option of the submitted Gromacs tools.  In the Gromacs documentation (https://manual.gromacs.org/documentation/2018-current/onlinehelp/gmx-trjconv.html) it says about the -dt option:

> Only write/use frame when t MOD dt = first time (ps)

However, when -dt is set to 1 and the spacing between frames is less than 1 ps, not every frame is processed, although t MOD 1 should be 0 for all (integer) values of t.  When setting -dt 0, every frame is processed (although t MOD 0 should not be defined.  However, 0 is the default value for -dt according to the docs).

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [N/A].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] New/changed features are tracked in CHANGELOG.rst.
* [ ] The CI workflow is passing.
