### PR TITLE
[energy.sh]: Fix Call of `decompres.sh`

### DIFF
--- a/analysis/lintf2_ether/gmx/energy.sh
+++ b/analysis/lintf2_ether/gmx/energy.sh
@@ -66,7 +66,11 @@ source "${bash_dir}/load_gmx.sh" "${gmx_lmod}" "${gmx_exe}" || exit
 echo -e "\n"
 echo "Decompressing input file(s) if necessary..."
 infile="${settings}_out_${system}.edr"
-decompressed=$("${bash_dir}/decompress.sh" "${infile}" "--keep --verbose")
+decompressed=$(bash \
+    "${bash_dir}/decompress.sh" \
+    "${infile}" \
+    --keep \
+    --verbose)
 
 ########################################################################
 # Start the Analysis                                                   #


### PR DESCRIPTION
# [energy.sh]: Fix Call of `decompres.sh`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Call `decompres.sh` as `bash decompres.sh` rather than simply as `decompres.sh`.  This avoids permission errors if `decompres.sh` is not executable.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] New/changed features are tracked in CHANGELOG.rst.
* [ ] The CI workflow is passing.
