### PR TITLE
[submit_mdt_analyses_lintf2_ether.py]: Additional `--scripts` Options

### DIFF
--- a/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
@@ -68,6 +68,8 @@ Required Arguments
         :11:    All renewal event analyses.
         :11.1:  All scripts extracting renewal events.
         :11.2:  All scripts calculating renewal event lifetimes.
+        :11.3:  All "normal" bulk renewal event lifetimes.
+        :11.4:  All spatially discretized renewal event lifetimes.
 
 Options for Trajectory Reading
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,9 +352,7 @@ REQUIRE_XTC_UNWRAPPED = (
 REQUIRE_DTRJ_DISCRETE_Z = (
     # `${settings}_${system}_discrete-z_Li_dtrj.npy`
     "discrete-z_Li_state_lifetime_discrete",
-    "renewal_events_Li-ether_state_lifetime",
     "renewal_events_Li-ether_state_lifetime_discrete",
-    "renewal_events_Li-NTf2_state_lifetime",
     "renewal_events_Li-NTf2_state_lifetime_discrete",
 )
 REQUIRE_DTRJ_RENEWAL_ETHER = (
@@ -600,6 +600,8 @@ if __name__ == "__main__":  # noqa: C901
             "  11 = All renewal event analyses."
             "  11.1 = All scripts extracting renewal events."
             "  11.2 = All scripts calculating renewal event lifetimes."
+            "  11.3 = All 'normal' bulk renewal event lifetimes."
+            "  11.4 = All spatially discretized renewal event lifetimes."
         ),
     )
     parser_trj_reading = parser.add_argument_group(
@@ -1001,6 +1003,13 @@ if __name__ == "__main__":  # noqa: C901
                 "unwrapped compressed trajectory", XTC_FILE_UNWRAPPED
             )
         elif script == "11.2":  # All renewal event lifetimes.
+            files.setdefault("discretized trajectory", DTRJ_DISCRETE_Z_FILE)
+            files.setdefault("discretized trajectory", DTRJ_RENEWAL_ETHER_FILE)
+            files.setdefault("discretized trajectory", DTRJ_RENEWAL_TFSI_FILE)
+        elif script == "11.3":  # All bulk renewal event lifetimes.
+            files.setdefault("discretized trajectory", DTRJ_RENEWAL_ETHER_FILE)
+            files.setdefault("discretized trajectory", DTRJ_RENEWAL_TFSI_FILE)
+        elif script == "11.4":  # All spatially discretized renew times.
             files.setdefault("discretized trajectory", DTRJ_DISCRETE_Z_FILE)
             files.setdefault("discretized trajectory", DTRJ_RENEWAL_ETHER_FILE)
             files.setdefault("discretized trajectory", DTRJ_RENEWAL_TFSI_FILE)
@@ -1475,6 +1484,23 @@ if __name__ == "__main__":  # noqa: C901
             if (
                 "renewal_events" in batch_script
                 and "state_lifetime" in batch_script
+            ):
+                n_scripts_submitted += _submit(args_sbatch, batch_script)
+    if "11.3" in args["scripts"].split():
+        # All "normal" bulk renewal event lifetimes.
+        for batch_script in posargs.keys():
+            if (
+                "renewal_events" in batch_script
+                and "state_lifetime" in batch_script
+                and "discrete" not in batch_script
+            ):
+                n_scripts_submitted += _submit(args_sbatch, batch_script)
+    if "11.3" in args["scripts"].split():
+        # All spatially discretized renewal event lifetimes.
+        for batch_script in posargs.keys():
+            if (
+                "renewal_events" in batch_script
+                and "state_lifetime_discrete" in batch_script
             ):
                 n_scripts_submitted += _submit(args_sbatch, batch_script)
     print("Submitted {} jobs".format(n_scripts_submitted))


### PR DESCRIPTION
# [submit_mdt_analyses_lintf2_ether.py]: Additional `--scripts` Options

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->
Add the additional `--script` options

* 11.3: All "normal" bulk renewal event lifetimes.
* 11.4: All spatially discretized renewal event lifetimes.

This allows users to submit "normal" bulk renewal event lifetimes and spatially discretized renewal event lifetimes separately which was not possible before.

Additionally, remove the analysis scripts
`renewal_events_Li-ether_state_lifetime.sh` and
`renewal_events_Li-NTf2_state_lifetime.sh` from the list of scripts that require the spatially discretized
`${settings}_${system}_discrete-z_Li_dtrj.npy` trajectory.  The scripts were listed wrongly there.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] New/changed features are tracked in CHANGELOG.rst.
* [ ] The CI workflow is passing.
