### PR TITLE
Fix the Default Value of the `--every` Option of `submit_gmx_analyses_lintf2_ether.py`

### DIFF
--- a/analysis/lintf2_ether/gmx/.rdf_slab-z_Li-com.sh
+++ b/analysis/lintf2_ether/gmx/.rdf_slab-z_Li-com.sh
@@ -108,6 +108,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -116,8 +125,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" \
-        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg.gz" \
+        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}nm_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/.rdf_slab-z_NTf2-com.sh
+++ b/analysis/lintf2_ether/gmx/.rdf_slab-z_NTf2-com.sh
@@ -107,6 +107,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -115,8 +124,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" \
-        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg.gz" \
+        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}nm_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/.rdf_slab-z_ether-com.sh
+++ b/analysis/lintf2_ether/gmx/.rdf_slab-z_ether-com.sh
@@ -104,6 +104,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -112,8 +121,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" \
-        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg.gz" \
+        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}nm_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/density-z_charge.sh
+++ b/analysis/lintf2_ether/gmx/density-z_charge.sh
@@ -99,6 +99,14 @@ echo "${selection}" |
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -107,7 +115,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/density-z_mass.sh
+++ b/analysis/lintf2_ether/gmx/density-z_mass.sh
@@ -99,6 +99,14 @@ echo "${selection}" |
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -107,7 +115,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/density-z_number.sh
+++ b/analysis/lintf2_ether/gmx/density-z_number.sh
@@ -99,6 +99,14 @@ echo "${selection}" |
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -107,7 +115,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/potential-z.sh
+++ b/analysis/lintf2_ether/gmx/potential-z.sh
@@ -87,6 +87,16 @@ echo 0 |
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+gzip --best --verbose "${settings}_${system}_charge_density-z.xvg" || exit
+gzip --best --verbose "${settings}_${system}_field-z.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -95,9 +105,9 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
-        "${settings}_${system}_charge_density-z.xvg" \
-        "${settings}_${system}_field-z.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
+        "${settings}_${system}_charge_density-z.xvg.gz" \
+        "${settings}_${system}_field-z.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_Li-com.sh
+++ b/analysis/lintf2_ether/gmx/rdf_Li-com.sh
@@ -99,6 +99,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -107,8 +116,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
-        "${settings}_${system}_cn${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
+        "${settings}_${system}_cn${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_Li.sh
+++ b/analysis/lintf2_ether/gmx/rdf_Li.sh
@@ -85,6 +85,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -93,8 +102,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
-        "${settings}_${system}_cn${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
+        "${settings}_${system}_cn${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_NBT.sh
+++ b/analysis/lintf2_ether/gmx/rdf_NBT.sh
@@ -85,6 +85,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -93,8 +102,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
-        "${settings}_${system}_cn${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
+        "${settings}_${system}_cn${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_NTf2-com.sh
+++ b/analysis/lintf2_ether/gmx/rdf_NTf2-com.sh
@@ -98,6 +98,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -106,8 +115,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
-        "${settings}_${system}_cn${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
+        "${settings}_${system}_cn${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_OE.sh
+++ b/analysis/lintf2_ether/gmx/rdf_OE.sh
@@ -85,6 +85,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -93,8 +102,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
-        "${settings}_${system}_cn${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
+        "${settings}_${system}_cn${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_ether-com.sh
+++ b/analysis/lintf2_ether/gmx/rdf_ether-com.sh
@@ -95,6 +95,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -103,8 +112,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.xvg" \
-        "${settings}_${system}_cn${analysis}.xvg" \
+        "${settings}_${system}_${analysis}.xvg.gz" \
+        "${settings}_${system}_cn${analysis}.xvg.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_slab-z_Li.sh
+++ b/analysis/lintf2_ether/gmx/rdf_slab-z_Li.sh
@@ -93,6 +93,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -101,8 +110,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" \
-        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg.gz" \
+        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}nm_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_slab-z_NBT.sh
+++ b/analysis/lintf2_ether/gmx/rdf_slab-z_NBT.sh
@@ -91,6 +91,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -99,8 +108,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" \
-        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg.gz" \
+        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}nm_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/rdf_slab-z_OE.sh
+++ b/analysis/lintf2_ether/gmx/rdf_slab-z_OE.sh
@@ -90,6 +90,15 @@ ${gmx_exe} rdf \
 echo "================================================================="
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" || exit
+gzip --best --verbose "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -98,8 +107,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg" \
-        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}nm.xvg.gz" \
+        "${settings}_${system}_cn${analysis}_${zmin}-${zmax}nm.xvg.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}nm_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
@@ -57,8 +57,12 @@ Options for Trajectory Reading
     :file:`${settings}_out_${system}.log`.  Reading from |log_file|\s
     compressed with gzip, bzip2, XZ or LZMA is supported.
 --every
-    Only use frame if t MOD every == first time (in ps).  Default:
-    ``0``.
+    Read every n-th frame from the trajectory.  The value given here is
+    passed to the -skip option of the submitted Gromacs tools that
+    support this option.  If the -skip option is not supported, the
+    value of \--every is passed to the -dt option.  For Gromacs tools
+    that do not support either of the two options, \--every has no
+    effect.  Default: ``1``.
 
 Options for MSD Calculation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -455,12 +459,11 @@ if __name__ == "__main__":  # noqa: C901
     )
     parser_trj_reading.add_argument(
         "--every",
-        type=float,
+        type=int,
         required=False,
-        default=0,
+        default=1,
         help=(
-            "Only use frame if t MOD every == first time (in ps).  Default:"
-            " %(default)s."
+            "Read every n-th frame from the trajectory.  Default: %(default)s."
         ),
     )
     parser_msd = parser.add_argument_group(title="Options for MSD Calculation")

--- a/analysis/lintf2_ether/gmx/trjconv_nojump.sh
+++ b/analysis/lintf2_ether/gmx/trjconv_nojump.sh
@@ -32,7 +32,7 @@ system=${4}   # The name of the system to analyze
 settings=${5} # The used simulation settings
 begin=${6}    # First frame to read from trajectory in ps
 end=${7}      # Last frame to read from trajectory in ps
-dt=${8}       # Only use frame when t MOD dt = first time
+skip=${8}     # Only use every n-th frame
 
 echo -e "\n"
 echo "Parsed arguments:"
@@ -43,7 +43,7 @@ echo "system   = ${system}"
 echo "settings = ${settings}"
 echo "begin    = ${begin}"
 echo "end      = ${end}"
-echo "dt       = ${dt}"
+echo "skip     = ${skip}"
 
 if [[ ! -d ${bash_dir} ]]; then
     echo
@@ -74,7 +74,7 @@ echo "System" |
         -o "${settings}_out_${system}_pbc_whole_mol_nojump.xtc" \
         -b "${begin}" \
         -e "${end}" \
-        -dt "${dt}" \
+        -skip "${skip}" \
         -pbc nojump ||
     exit
 echo "================================================================="

--- a/analysis/lintf2_ether/gmx/trjconv_whole.sh
+++ b/analysis/lintf2_ether/gmx/trjconv_whole.sh
@@ -32,7 +32,7 @@ system=${4}   # The name of the system to analyze
 settings=${5} # The used simulation settings
 begin=${6}    # First frame to read from trajectory in ps
 end=${7}      # Last frame to read from trajectory in ps
-dt=${8}       # Only use frame when t MOD dt = first time
+skip=${8}     # Only use every n-th frame
 
 echo -e "\n"
 echo "Parsed arguments:"
@@ -43,7 +43,7 @@ echo "system   = ${system}"
 echo "settings = ${settings}"
 echo "begin    = ${begin}"
 echo "end      = ${end}"
-echo "dt       = ${dt}"
+echo "skip     = ${skip}"
 
 if [[ ! -d ${bash_dir} ]]; then
     echo
@@ -74,7 +74,7 @@ echo "System" |
         -o "${settings}_out_${system}_pbc_whole.xtc" \
         -b "${begin}" \
         -e "${end}" \
-        -dt "${dt}" \
+        -skip "${skip}" \
         -pbc whole ||
     exit
 echo "================================================================="

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_Li.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_Li.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_1nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,7 +110,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_NBT.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_NBT.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_1nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,7 +110,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_OBT.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_OBT.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_1nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,8 +110,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}${analysis}_${zmin}-${zmax}A.txt" \
-        "${settings}_${system}${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \
         "${system}" \

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_OE.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_1nn_OE.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_1nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,7 +110,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_Li.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_Li.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_2nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,7 +110,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_NBT.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_NBT.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_2nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,7 +110,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_OBT.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_OBT.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_2nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,7 +110,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_OE.sh
+++ b/analysis/lintf2_ether/mdt/axial_hex_dist_2nn_OE.sh
@@ -89,7 +89,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/axial_hex_distribution_2nn.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -110,7 +110,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_Li-O.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_Li-O.sh
@@ -76,7 +76,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -95,7 +95,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_Li-OBT.sh
@@ -76,7 +76,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -95,7 +95,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_Li-OE.sh
@@ -76,7 +76,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -95,7 +95,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_O-Li.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_O-Li.sh
@@ -76,7 +76,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -95,7 +95,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_OBT-Li.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_OBT-Li.sh
@@ -76,7 +76,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -95,7 +95,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_OE-Li.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_OE-Li.sh
@@ -76,7 +76,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -95,7 +95,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_at_pos_change_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_at_pos_change_Li-OBT.sh
@@ -83,9 +83,19 @@ ${py_exe} -u \
     --ref "type Li" \
     --sel "type OBT" \
     -c "${cutoff}" \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
+
+########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_stay.txt" || exit
+gzip --best --verbose "${settings}_${system}_${analysis}_leave.txt" || exit
+gzip --best --verbose "${settings}_${system}_${analysis}_bins.txt" || exit
 
 ########################################################################
 # Cleanup                                                              #
@@ -96,9 +106,9 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_stay.txt" \
-        "${settings}_${system}_${analysis}_leave.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}_stay.txt.gz" \
+        "${settings}_${system}_${analysis}_leave.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_at_pos_change_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_at_pos_change_Li-OE.sh
@@ -83,9 +83,19 @@ ${py_exe} -u \
     --ref "type Li" \
     --sel "type OE" \
     -c "${cutoff}" \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
+
+########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}_stay.txt" || exit
+gzip --best --verbose "${settings}_${system}_${analysis}_leave.txt" || exit
+gzip --best --verbose "${settings}_${system}_${analysis}_bins.txt" || exit
 
 ########################################################################
 # Cleanup                                                              #
@@ -96,9 +106,9 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_stay.txt" \
-        "${settings}_${system}_${analysis}_leave.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}_stay.txt.gz" \
+        "${settings}_${system}_${analysis}_leave.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OBT.sh
@@ -80,7 +80,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -100,7 +100,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OE.sh
@@ -80,7 +80,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/contact_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+    -o "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -100,7 +100,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt" \
+        "${settings}_${system}_${analysis}_${zmin}-${zmax}A.txt.gz" \
         "${settings}_${system}_${analysis}_${zmin}-${zmax}A_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/discrete-z_Li.sh
+++ b/analysis/lintf2_ether/mdt/discrete-z_Li.sh
@@ -80,8 +80,8 @@ ${py_exe} -u \
     --every "${every}" \
     --sel "type Li" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" \
-    --bins-out "${settings}_${system}_${analysis}_bins.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" \
+    --bins-out "${settings}_${system}_${analysis}_bins.txt.gz" ||
     exit
 echo "================================================================="
 
@@ -94,7 +94,7 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     cp -v \

--- a/analysis/lintf2_ether/mdt/energy_dist.sh
+++ b/analysis/lintf2_ether/mdt/energy_dist.sh
@@ -86,7 +86,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/gmx/plot_energy_dist.py" \
     -f "${infile}" \
     --plot-out "${settings}_${system}_${analysis}_${begin}-${end}frame.pdf" \
-    --stats-out "${settings}_${system}_${analysis}_${begin}-${end}frame.txt" \
+    --stats-out "${settings}_${system}_${analysis}_${begin}-${end}frame.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -105,7 +105,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/gmx/plot_energy_dist.py" \
     -f "${infile}" \
     --plot-out "${settings}_${system}_${analysis}_diff_${begin}-${end}frame.pdf" \
-    --stats-out "${settings}_${system}_${analysis}_diff_${begin}-${end}frame.txt" \
+    --stats-out "${settings}_${system}_${analysis}_diff_${begin}-${end}frame.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -135,9 +135,9 @@ if [[ ! -d ${save_dir} ]]; then
     mkdir -v "${save_dir}" || exit
     mv -v \
         "${settings}_${system}_${analysis}_${begin}-${end}frame.pdf" \
-        "${settings}_${system}_${analysis}_${begin}-${end}frame.txt" \
+        "${settings}_${system}_${analysis}_${begin}-${end}frame.txt.gz" \
         "${settings}_${system}_${analysis}_diff_${begin}-${end}frame.pdf" \
-        "${settings}_${system}_${analysis}_diff_${begin}-${end}frame.txt" \
+        "${settings}_${system}_${analysis}_diff_${begin}-${end}frame.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/lig_change_at_pos_change_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/lig_change_at_pos_change_Li-OBT.sh
@@ -88,7 +88,7 @@ ${py_exe} -u \
     -c "${cutoff}" \
     --lag "${lag_compare}" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "=================================================================="
 
@@ -100,6 +100,15 @@ if [[ -f ${settings}_${system}_${analysis}_contacts.txt ]]; then
 fi
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.txt" || exit
+gzip --best --verbose "${settings}_${system}_${analysis}_bins.txt" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -108,8 +117,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/lig_change_at_pos_change_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/lig_change_at_pos_change_Li-OE.sh
@@ -88,7 +88,7 @@ ${py_exe} -u \
     -c "${cutoff}" \
     --lag "${lag_compare}" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "=================================================================="
 
@@ -100,6 +100,15 @@ if [[ -f ${settings}_${system}_${analysis}_contacts.txt ]]; then
 fi
 
 ########################################################################
+# Compress output file(s)                                              #
+########################################################################
+
+echo -e "\n"
+echo "Compressing output file(s)..."
+gzip --best --verbose "${settings}_${system}_${analysis}.txt" || exit
+gzip --best --verbose "${settings}_${system}_${analysis}_bins.txt" || exit
+
+########################################################################
 # Cleanup                                                              #
 ########################################################################
 
@@ -108,8 +117,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_Li-OBT.sh
@@ -81,7 +81,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/lig_change_at_pos_change_blocks.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -94,8 +94,8 @@ ${py_exe} -u \
     --min-block-size "${min_block_size}" \
     --max-gap-size "${max_gap_size}" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" \
-    --bins-out "${settings}_${system}_${analysis}_bins.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" \
+    --bins-out "${settings}_${system}_${analysis}_bins.txt.gz" ||
     exit
 echo "=================================================================="
 
@@ -108,8 +108,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_Li-OE.sh
@@ -81,7 +81,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/lig_change_at_pos_change_blocks.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -94,8 +94,8 @@ ${py_exe} -u \
     --min-block-size "${min_block_size}" \
     --max-gap-size "${max_gap_size}" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" \
-    --bins-out "${settings}_${system}_${analysis}_bins.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" \
+    --bins-out "${settings}_${system}_${analysis}_bins.txt.gz" ||
     exit
 echo "=================================================================="
 
@@ -108,8 +108,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_hist_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_hist_Li-OBT.sh
@@ -81,7 +81,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/lig_change_at_pos_change_blocks_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -94,8 +94,8 @@ ${py_exe} -u \
     --min-block-size "${min_block_size}" \
     --max-gap-size "${max_gap_size}" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" \
-    --bins-out "${settings}_${system}_${analysis}_bins.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" \
+    --bins-out "${settings}_${system}_${analysis}_bins.txt.gz" ||
     exit
 echo "=================================================================="
 
@@ -108,8 +108,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_hist_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/lig_change_at_pos_change_blocks_hist_Li-OE.sh
@@ -81,7 +81,7 @@ ${py_exe} -u \
     "${mdt_path}/scripts/structure/lig_change_at_pos_change_blocks_hist.py" \
     -f "${settings}_out_${system}_pbc_whole_mol.xtc" \
     -s "${settings}_${system}.tpr" \
-    -o "${settings}_${system}_${analysis}.txt" \
+    -o "${settings}_${system}_${analysis}.txt.gz" \
     -b "${begin}" \
     -e "${end}" \
     --every "${every}" \
@@ -94,8 +94,8 @@ ${py_exe} -u \
     --min-block-size "${min_block_size}" \
     --max-gap-size "${max_gap_size}" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" \
-    --bins-out "${settings}_${system}_${analysis}_bins.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" \
+    --bins-out "${settings}_${system}_${analysis}_bins.txt.gz" ||
     exit
 echo "=================================================================="
 
@@ -108,8 +108,8 @@ if [[ ! -d ${save_dir} ]]; then
     echo -e "\n"
     mkdir -v "${save_dir}" || exit
     mv -v \
-        "${settings}_${system}_${analysis}.txt" \
-        "${settings}_${system}_${analysis}_bins.txt" \
+        "${settings}_${system}_${analysis}.txt.gz" \
+        "${settings}_${system}_${analysis}_bins.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/msd_layer_Li.sh
+++ b/analysis/lintf2_ether/mdt/msd_layer_Li.sh
@@ -86,7 +86,7 @@ ${py_exe} -u \
     --restart "${restart}" \
     --sel "type Li" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
 

--- a/analysis/lintf2_ether/mdt/msd_layer_NBT.sh
+++ b/analysis/lintf2_ether/mdt/msd_layer_NBT.sh
@@ -86,7 +86,7 @@ ${py_exe} -u \
     --restart "${restart}" \
     --sel "type NBT" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
 

--- a/analysis/lintf2_ether/mdt/msd_layer_NTf2.sh
+++ b/analysis/lintf2_ether/mdt/msd_layer_NTf2.sh
@@ -87,7 +87,7 @@ ${py_exe} -u \
     --sel "resname ntf2" \
     --com residues \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
 

--- a/analysis/lintf2_ether/mdt/msd_layer_OBT.sh
+++ b/analysis/lintf2_ether/mdt/msd_layer_OBT.sh
@@ -86,7 +86,7 @@ ${py_exe} -u \
     --restart "${restart}" \
     --sel "type OBT" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
 

--- a/analysis/lintf2_ether/mdt/msd_layer_OE.sh
+++ b/analysis/lintf2_ether/mdt/msd_layer_OE.sh
@@ -86,7 +86,7 @@ ${py_exe} -u \
     --restart "${restart}" \
     --sel "type OE" \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
 

--- a/analysis/lintf2_ether/mdt/msd_layer_ether.sh
+++ b/analysis/lintf2_ether/mdt/msd_layer_ether.sh
@@ -97,7 +97,7 @@ ${py_exe} -u \
     --sel "resname ${solvent}" \
     --com residues \
     -d z \
-    --bins "${settings}_${system}_density-z_number_Li_binsA.txt" ||
+    --bins "${settings}_${system}_density-z_number_Li_binsA.txt.gz" ||
     exit
 echo "================================================================="
 

--- a/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
@@ -387,23 +387,23 @@ REQUIRE_XTC_UNWRAPPED = (
     "renewal_events_Li-NTf2",
 )
 REQUIRE_DTRJ_DISCRETE_Z = (
-    # `${settings}_${system}_discrete-z_Li_dtrj.npy`
+    # `${settings}_${system}_discrete-z_Li_dtrj.npy` or `.npz`
     "discrete-z_Li_state_lifetime_discrete",
     "renewal_events_Li-ether_state_lifetime_discrete",
     "renewal_events_Li-NTf2_state_lifetime_discrete",
 )
 REQUIRE_DTRJ_RENEWAL_ETHER = (
-    # `${settings}_${system}_renewal_events_Li-ether_dtrj.npy`
+    # `${settings}_${system}_renewal_events_Li-ether_dtrj.npy` or `.npz`
     "renewal_events_Li-ether_state_lifetime",
     "renewal_events_Li-ether_state_lifetime_discrete",
 )
 REQUIRE_DTRJ_RENEWAL_TFSI = (
-    # `${settings}_${system}_renewal_events_Li-NTf2_dtrj.npy`
+    # `${settings}_${system}_renewal_events_Li-NTf2_dtrj.npy` or `.npz`
     "renewal_events_Li-NTf2_state_lifetime",
     "renewal_events_Li-NTf2_state_lifetime_discrete",
 )
 REQUIRE_BIN_FILE = (
-    # `${settings}_${system}_density-z_number_Li_binsA.txt`
+    # `${settings}_${system}_density-z_number_Li_binsA.txt.gz`
     "contact_hist_at_pos_change_Li-OBT",
     "contact_hist_at_pos_change_Li-OE",
     "discrete-z_Li",
@@ -904,7 +904,7 @@ if __name__ == "__main__":  # noqa: C901
     DTRJ_RENEWAL_TFSI_FILE = (
         gmx_infile_pattern + "_renewal_events_Li-NTf2_dtrj.npy"
     )
-    BIN_FILE = gmx_infile_pattern + "_density-z_number_Li_binsA.txt"
+    BIN_FILE = gmx_infile_pattern + "_density-z_number_Li_binsA.txt.gz"
 
     print("Processing parsed arguments...")
     if args["binwidth"] <= 0:


### PR DESCRIPTION
# Fix the Default Value of the `--every` Option of `submit_gmx_analyses_lintf2_ether.py`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* Change the default value of the `--every` option from 0 to 1. The value of the `--every` option is passed to the `-dt` option of the submitted Gromacs tools that support this option.  The default value was set to 0 in PR #74, because `gmx trjconv` did not process all frames when `-dt` was set to 1 and the spacing between trajectory frames was less than 1 ps. However, it now turned out that the other Gromacs tools only process the first frame when `-dt` is set to 0.  Therefore, we reset the default value for `--every` (i.e. `-dt`) to 1.
* Replace the `-dt` option for `gmx trjconv` with `-skip`, which should be more robust (see https://www.mail-archive.com/gmx-users@gromacs.org/msg35903.html and https://www.mail-archive.com/gmx-users@gromacs.org/msg06868.html).
* Compress literally all output text files with gzip.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
