### PR TITLE
[`submit_gmx_analyses_lintf2_ether.py`]: Replace `--every` Option by Gromacs-Specific `--skip` and `--dt` Options

### DIFF
--- a/analysis/lintf2_ether/gmx/energy.sh
+++ b/analysis/lintf2_ether/gmx/energy.sh
@@ -32,6 +32,7 @@ system=${4}   # The name of the system to analyze
 settings=${5} # The used simulation settings
 begin=${6}    # First frame to read from trajectory in ps
 end=${7}      # Last frame to read from trajectory in ps
+skip=${8}     # Skip every n-th frame
 
 echo -e "\n"
 echo "Parsed arguments:"
@@ -42,6 +43,7 @@ echo "system   = ${system}"
 echo "settings = ${settings}"
 echo "begin    = ${begin}"
 echo "end      = ${end}"
+echo "skip     = ${skip}"
 
 if [[ ! -d ${bash_dir} ]]; then
     echo
@@ -98,7 +100,8 @@ echo -e \
         -s "${settings}_${system}.tpr" \
         -o "${outfile}" \
         -b "${begin}" \
-        -e "${end}" ||
+        -e "${end}" \
+        -skip "${skip}" ||
     exit
 echo "================================================================="
 


### PR DESCRIPTION
# [`submit_gmx_analyses_lintf2_ether.py`]: Replace `--every` Option by Gromacs-Specific `--skip` and `--dt` Options

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Related Pull Requests

* #119 
* #74 

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [ ] Non-breaking (backward-compatible) change.
* [x] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* `submit_gmx_analyses_lintf2_ether.py`: Replace the `--every` option ("read every n-th frame from the trajectory") by a `--skip` and `--dt` option.  The new options mirror the `-skip` and `-dt` options of Gromacs analysis tools and therefore should by less confusing.
* Add `-skip` option to the call of `gmx energy`.

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
