### PR TITLE
`submit_gmx_analyses_lintf2_ether.py`: Fix Argparse Help Text and The Docstring Format

### DIFF
--- a/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
@@ -58,14 +58,14 @@ Options for Trajectory Reading
     compressed with gzip, bzip2, XZ or LZMA is supported.
 --skip
     Read every n-th frame from the trajectory.  Takes precedence over
-    `--dt` for Gromacs tools that support the `-skip` option.  Has no
-    effect for Gromacs tools that do not support the `-skip` option.
+    \--dt for Gromacs tools that support the -skip option.  Has no
+    effect for Gromacs tools that do not support the -skip option.
     Default: ``1``.
 --dt
     Only read frames when ``t_frame % dt == t0`` (all times in ps).  If
-    you want all frames to be read, set --dt to the time step between
+    you want all frames to be read, set \--dt to the time step between
     two trajectory frames.  Has no effect for Gromacs tools that do not
-    support the `-dt` option.  Default: ``1``.
+    support the -dt option.  Default: ``1``.
 
 Options for MSD Calculation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -477,7 +477,7 @@ if __name__ == "__main__":  # noqa: C901
         required=False,
         default=1,
         help=(
-            "Only read frames when ``t_frame % dt == t0`` (all times in ps)."
+            "Only read frames when ``t_frame %% dt == t0`` (all times in ps)."
             "  Has no effect for Gromacs tools that do not support the -dt"
             " option.  Default: %(default)s."
         ),


### PR DESCRIPTION
# `submit_gmx_analyses_lintf2_ether.py`: Fix Argparse Help Text and The Docstring Format

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* `submit_gmx_analyses_lintf2_ether.py`: Fix Argparse Help Text and The Docstring Format

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
