### PR TITLE
Back-Jump Probabilities: Get Normalization Factors

### DIFF
--- a/analysis/lintf2_ether/mdt/discrete-z_Li_back_jump_prob_discrete.sh
+++ b/analysis/lintf2_ether/mdt/discrete-z_Li_back_jump_prob_discrete.sh
@@ -75,6 +75,7 @@ ${py_exe} -u \
     --f1 "${infile}" \
     --f2 "${infile}" \
     -o "${settings}_${system}_${analysis}_continuous.txt.gz" \
+    --norm-out "${settings}_${system}_${analysis}_continuous_norm.txt.gz" \
     -b "0" \
     -e "-1" \
     --every "1" \
@@ -90,6 +91,7 @@ ${py_exe} -u \
     --f1 "${infile}" \
     --f2 "${infile}" \
     -o "${settings}_${system}_${analysis}.txt.gz" \
+    --norm-out "${settings}_${system}_${analysis}_norm.txt.gz" \
     -b "0" \
     -e "-1" \
     --every "1" ||
@@ -106,7 +108,9 @@ if [[ ! -d ${save_dir} ]]; then
     mkdir -v "${save_dir}" || exit
     mv -v \
         "${settings}_${system}_${analysis}.txt.gz" \
+        "${settings}_${system}_${analysis}_norm.txt.gz" \
         "${settings}_${system}_${analysis}_continuous.txt.gz" \
+        "${settings}_${system}_${analysis}_continuous_norm.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/renewal_events_Li-NTf2_back_jump_prob_discrete.sh
+++ b/analysis/lintf2_ether/mdt/renewal_events_Li-NTf2_back_jump_prob_discrete.sh
@@ -80,6 +80,7 @@ ${py_exe} -u \
     --f1 "${infile1}" \
     --f2 "${infile2}" \
     -o "${settings}_${system}_${analysis}_discard-neg_continuous.txt.gz" \
+    --norm-out "${settings}_${system}_${analysis}_discard-neg_continuous_norm.txt.gz" \
     -b "0" \
     -e "-1" \
     --every "1" \
@@ -96,6 +97,7 @@ ${py_exe} -u \
     --f1 "${infile1}" \
     --f2 "${infile2}" \
     -o "${settings}_${system}_${analysis}_discard-neg.txt.gz" \
+    --norm-out "${settings}_${system}_${analysis}_discard-neg_norm.txt.gz" \
     -b "0" \
     -e "-1" \
     --every "1" \
@@ -113,7 +115,9 @@ if [[ ! -d ${save_dir} ]]; then
     mkdir -v "${save_dir}" || exit
     mv -v \
         "${settings}_${system}_${analysis}_discard-neg.txt.gz" \
+        "${settings}_${system}_${analysis}_discard-neg_norm.txt.gz" \
         "${settings}_${system}_${analysis}_discard-neg_continuous.txt.gz" \
+        "${settings}_${system}_${analysis}_discard-neg_continuous_norm.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \

--- a/analysis/lintf2_ether/mdt/renewal_events_Li-ether_back_jump_prob_discrete.sh
+++ b/analysis/lintf2_ether/mdt/renewal_events_Li-ether_back_jump_prob_discrete.sh
@@ -80,6 +80,7 @@ ${py_exe} -u \
     --f1 "${infile1}" \
     --f2 "${infile2}" \
     -o "${settings}_${system}_${analysis}_discard-neg_continuous.txt.gz" \
+    --norm-out "${settings}_${system}_${analysis}_discard-neg_continuous_norm.txt.gz" \
     -b "0" \
     -e "-1" \
     --every "1" \
@@ -96,6 +97,7 @@ ${py_exe} -u \
     --f1 "${infile1}" \
     --f2 "${infile2}" \
     -o "${settings}_${system}_${analysis}_discard-neg.txt.gz" \
+    --norm-out "${settings}_${system}_${analysis}_discard-neg_norm.txt.gz" \
     -b "0" \
     -e "-1" \
     --every "1" \
@@ -113,7 +115,9 @@ if [[ ! -d ${save_dir} ]]; then
     mkdir -v "${save_dir}" || exit
     mv -v \
         "${settings}_${system}_${analysis}_discard-neg.txt.gz" \
+        "${settings}_${system}_${analysis}_discard-neg_norm.txt.gz" \
         "${settings}_${system}_${analysis}_discard-neg_continuous.txt.gz" \
+        "${settings}_${system}_${analysis}_discard-neg_continuous_norm.txt.gz" \
         "${settings}_${system}_${analysis}_slurm-${SLURM_JOB_ID}.out" \
         "${save_dir}"
     bash "${bash_dir}/cleanup_analysis.sh" \


### PR DESCRIPTION
# Back-Jump Probabilities: Get Normalization Factors

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Slurm job scripts `discrete-z_Li_back_jump_prob_discrete.sh`, `renewal_events_Li-ether_back_jump_prob_discrete.sh` and `renewal_events_Li-NTf2_back_jump_prob_discrete.sh`: Use the new command-line option of the MDTool script `back_jump_prob_discrete.py`, `--norm-out`, to receive an output file with the normalization factors used to calculate the back-jump probabilities (see https://github.com/andthum/mdtools/pull/201).

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
