### PR TITLE
Fix `--discretize` Option of Analysis Submit Scripts

### DIFF
--- a/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
@@ -331,7 +331,6 @@ def _submit_discretized(sbatch_opts, job_script, bins):
     sbatch += opthandler.optdict2str(
         sbatch_opts, skiped_opts=("None", "False"), dumped_vals=("True",)
     )
-    submit = sbatch
 
     n_jobs_submitted = 0
     for i, zmax in enumerate(bins[1:], 1):
@@ -339,6 +338,7 @@ def _submit_discretized(sbatch_opts, job_script, bins):
         slab_str = "_{:.{prec}f}-{:.{prec}f}nm".format(
             slab[0], slab[1], prec=ARG_PREC
         )
+        submit = sbatch
         if "job-name" not in sbatch_opts and "J" not in sbatch_opts:
             sbatch_jobname = " --job-name " + gmx_infile_pattern + "_"
             submit += sbatch_jobname + job_script + slab_str

--- a/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OBT.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --time=1-00:00:00
+#SBATCH --time=0-06:00:00
 #SBATCH --job-name="mdt_contact_hist_slab-z_Li-OBT"
 #SBATCH --output="mdt_contact_hist_slab-z_Li-OBT_slurm-%j.out"
 #SBATCH --nodes=1
-#SBATCH --cpus-per-task=2
-#SBATCH --mem=512M
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=1G
 # The above options are only default values that can be overwritten by
 # command-line arguments
 

--- a/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/contact_hist_slab-z_Li-OE.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --time=1-00:00:00
+#SBATCH --time=0-06:00:00
 #SBATCH --job-name="mdt_contact_hist_slab-z_Li-OE"
 #SBATCH --output="mdt_contact_hist_slab-z_Li-OE_slurm-%j.out"
 #SBATCH --nodes=1
-#SBATCH --cpus-per-task=2
-#SBATCH --mem=512M
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=1G
 # The above options are only default values that can be overwritten by
 # command-line arguments
 

--- a/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
@@ -522,7 +522,6 @@ def _submit_discretized(sbatch_opts, job_script, bins):
     sbatch += opthandler.optdict2str(
         sbatch_opts, skiped_opts=("None", "False"), dumped_vals=("True",)
     )
-    submit = sbatch
 
     n_jobs_submitted = 0
     for i, zmax in enumerate(bins[1:], 1):
@@ -530,6 +529,7 @@ def _submit_discretized(sbatch_opts, job_script, bins):
         slab_str = "_{:.{prec}f}-{:.{prec}f}A".format(
             slab[0], slab[1], prec=ARG_PREC
         )
+        submit = sbatch
         if "job-name" not in sbatch_opts and "J" not in sbatch_opts:
             sbatch_jobname = " --job-name " + gmx_infile_pattern + "_"
             submit += sbatch_jobname + job_script + slab_str
@@ -934,6 +934,7 @@ if __name__ == "__main__":  # noqa: C901
                 " file: '{}'.".format(GRO_FILE)
             )
         box_z = gmx.get_box_from_gro(GRO_FILE)[2]
+        box_z *= 10  # nm -> A
         args["zmin"] = 0.5 * (box_z - args["slabwidth"])
         args["zmax"] = 0.5 * (box_z + args["slabwidth"])
     elif args["zmax"] is None:
@@ -944,6 +945,7 @@ if __name__ == "__main__":  # noqa: C901
                 " manually".format(GRO_FILE)
             )
         args["zmax"] = gmx.get_box_from_gro(GRO_FILE)[2]
+        args["zmax"] *= 10  # nm -> A
     if args["zmax"] <= args["zmin"]:
         raise ValueError(
             "zmax ({}) must be greater than zmin"


### PR DESCRIPTION
# Fix `--discretize` Option of Analysis Submit Scripts

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* Python submit scripts `submit_gmx_analyses_lintf2_ether.py` and `submit_mdt_analyses_lintf2_ether.py`: Fix the function `_submit_discretized`: Reset the submit command after each loop instead of appending it.
* Python submit script `submit_mdt_analyses_lintf2_ether.py`: Convert the box length that is read from the `.gro` file from nanometers to Angstrom.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
