### PR TITLE
Fix Typo in Python Submit Scripts

### DIFF
--- a/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/gmx/submit_gmx_analyses_lintf2_ether.py
@@ -288,7 +288,7 @@ def _assemble_submit_cmd(sbatch_opts, job_script):
             "No such file: '{}'.  This might happen if you change the"
             " directory structure of this project".format(job_script_path)
         )
-    submit += " " + job_script_path + posargs[job_script]
+    submit += " " + job_script_path + " " + posargs[job_script]
     return submit
 
 
@@ -356,13 +356,13 @@ def _submit_discretized(sbatch_opts, job_script, bins):
             posargs[job_script] + slab, prec=ARG_PREC
         )
         job_script_path = os.path.abspath(os.path.join(FILE_ROOT, job_script))
-        job_script_path += ".sh "
+        job_script_path += ".sh"
         if not os.path.isfile(job_script_path):
             raise FileNotFoundError(
                 "No such file: '{}'.  This might happen if you change the"
                 " directory structure of this project".format(job_script_path)
             )
-        submit += " " + job_script_path + posargs_tmp
+        submit += " " + job_script_path + " " + posargs_tmp
         subproc.check_output(shlex.split(submit))
         n_jobs_submitted += 1
     return n_jobs_submitted

--- a/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
+++ b/analysis/lintf2_ether/mdt/submit_mdt_analyses_lintf2_ether.py
@@ -477,13 +477,13 @@ def _assemble_submit_cmd(sbatch_opts, job_script):
         sbatch_output = " --output " + gmx_infile_pattern + "_"
         submit += sbatch_output + job_script + "_slurm-%j.out"
     job_script_path = os.path.abspath(os.path.join(FILE_ROOT, job_script))
-    job_script_path += ".sh "
+    job_script_path += ".sh"
     if not os.path.isfile(job_script_path):
         raise FileNotFoundError(
             "No such file: '{}'.  This might happen if you change the"
             " directory structure of this project".format(job_script_path)
         )
-    submit += " " + job_script_path + posargs[job_script]
+    submit += " " + job_script_path + " " + posargs[job_script]
     return submit
 
 
@@ -567,13 +567,13 @@ def _submit_discretized(sbatch_opts, job_script, bins):
             posargs[job_script] + slab, prec=ARG_PREC
         )
         job_script_path = os.path.abspath(os.path.join(FILE_ROOT, job_script))
-        job_script_path += ".sh "
+        job_script_path += ".sh"
         if not os.path.isfile(job_script_path):
             raise FileNotFoundError(
                 "No such file: '{}'.  This might happen if you change the"
                 " directory structure of this project".format(job_script_path)
             )
-        submit += " " + job_script_path + posargs_tmp
+        submit += " " + job_script_path + " " + posargs_tmp
         subproc.check_output(shlex.split(submit))
         n_jobs_submitted += 1
     return n_jobs_submitted


### PR DESCRIPTION
# Fix Typo in Python Submit Scripts

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Python submit scripts `submit_gmx_analyses_lintf2_ether.py` and `submit_mdt_analyses_lintf2_ether.py`: Fix typo in Slurm job script name.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
