### PR TITLE
Update Requested Resources of the Slurm Job Scripts `densmap-z_ether.sh` and `lifetime_autocorr_Li-*.sh`

### DIFF
--- a/analysis/lintf2_ether/mdt/densmap-z_ether.sh
+++ b/analysis/lintf2_ether/mdt/densmap-z_ether.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=1-00:00:00
+#SBATCH --time=5-00:00:00
 #SBATCH --job-name="mdt_densmap-z_ether"
 #SBATCH --output="mdt_densmap-z_ether_slurm-%j.out"
 #SBATCH --nodes=1

--- a/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-NTf2.sh
+++ b/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-NTf2.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --time=7-00:00:00
+#SBATCH --time=2-00:00:00
 #SBATCH --job-name="mdt_lifetime_autocorr_Li-NTf2"
 #SBATCH --output="mdt_lifetime_autocorr_Li-NTf2_slurm-%j.out"
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=12G
+#SBATCH --mem=48G
 # The above options are only default values that can be overwritten by
 # command-line arguments
 

--- a/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-OBT.sh
+++ b/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-OBT.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --time=7-00:00:00
+#SBATCH --time=2-00:00:00
 #SBATCH --job-name="mdt_lifetime_autocorr_Li-OBT"
 #SBATCH --output="mdt_lifetime_autocorr_Li-OBT_slurm-%j.out"
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=16G
+#SBATCH --mem=48G
 # The above options are only default values that can be overwritten by
 # command-line arguments
 

--- a/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-OE.sh
+++ b/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-OE.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --time=7-00:00:00
+#SBATCH --time=2-00:00:00
 #SBATCH --job-name="mdt_lifetime_autocorr_Li-OE"
 #SBATCH --output="mdt_lifetime_autocorr_Li-OE_slurm-%j.out"
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=20G
+#SBATCH --mem=48G
 # The above options are only default values that can be overwritten by
 # command-line arguments
 

--- a/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-ether.sh
+++ b/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-ether.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --time=7-00:00:00
+#SBATCH --time=2-00:00:00
 #SBATCH --job-name="mdt_lifetime_autocorr_Li-ether"
 #SBATCH --output="mdt_lifetime_autocorr_Li-ether_slurm-%j.out"
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=12G
+#SBATCH --mem=24G
 # The above options are only default values that can be overwritten by
 # command-line arguments
 


### PR DESCRIPTION
# Update Requested Resources of the Slurm Job Scripts `densmap-z_ether.sh` and `lifetime_autocorr_Li-*.sh`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [ ] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* Slurm job script `analysis/lintf2_ether/mdt/densmap-z_ether.sh`: Increase time limit.
* Slurm job scripts `analysis/lintf2_ether/mdt/`lifetime_autocorr_Li-*.sh`: Decrease time limit and increase memory limit.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
