### PR TITLE
Increase Memory Limit of Slurm Job Script `lifetime_autocorr_Li-ether.sh`

### DIFF
--- a/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-ether.sh
+++ b/analysis/lintf2_ether/mdt/lifetime_autocorr_Li-ether.sh
@@ -5,7 +5,7 @@
 #SBATCH --output="mdt_lifetime_autocorr_Li-ether_slurm-%j.out"
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=24G
+#SBATCH --mem=28G
 # The above options are only default values that can be overwritten by
 # command-line arguments
 


### PR DESCRIPTION
# Increase Memory Limit of Slurm Job Script `lifetime_autocorr_Li-ether.sh`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [ ] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Increase the memory limit of the Slurm job script `lifetime_autocorr_Li-ether.sh`.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's Guide](https://hpcss.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
